### PR TITLE
ft: Add basic backend authentication

### DIFF
--- a/backend/trip-manager-api/.rubocop.yml
+++ b/backend/trip-manager-api/.rubocop.yml
@@ -1,0 +1,21 @@
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-graphql
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+Documentation:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 20
+Naming/MethodParameterName:
+  Enabled: false
+GraphQL/ArgumentDescription:
+  Enabled: false
+GraphQL/FieldDescription:
+  Enabled: false
+GraphQL/MaxComplexitySchema:
+  Enabled: false
+GraphQL/MaxDepthSchema:
+  Enabled: false

--- a/backend/trip-manager-api/Gemfile
+++ b/backend/trip-manager-api/Gemfile
@@ -1,31 +1,33 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.2"
+ruby '3.1.2'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 7.0.6"
+gem 'rails', '~> 7.0.6'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem "sprockets-rails"
+gem 'sprockets-rails'
 
 # Use postgresql as the database for Active Record
-gem "pg", "~> 1.1"
+gem 'pg', '~> 1.1'
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 5.0"
+gem 'puma', '~> 5.0'
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-gem "importmap-rails"
+gem 'importmap-rails'
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem "turbo-rails"
+gem 'turbo-rails'
 
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
-gem "stimulus-rails"
+gem 'stimulus-rails'
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem "jbuilder"
+gem 'jbuilder'
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
@@ -34,16 +36,16 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-gem "bcrypt", "~> 3.1.7"
+gem 'bcrypt', '~> 3.1.7'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", require: false
+gem 'bootsnap', require: false
 
-gem "graphql"
-gem "jwt"
+gem 'graphql'
+gem 'jwt'
 
 # Use Sass to process CSS
 # gem "sassc-rails"
@@ -53,16 +55,19 @@ gem "jwt"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'debug', platforms: %i[mri mingw x64_mingw]
 
-  gem "bundler-audit"
-  gem "brakeman"
-  gem "rubocop"
+  gem 'brakeman', require: false
+  gem 'bundler-audit', require: false
+  gem 'rubocop', require: false
+  gem 'rubocop-graphql', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
 end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem "web-console"
+  gem 'web-console'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
@@ -70,12 +75,12 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 
-  gem "graphiql-rails"
+  gem 'graphiql-rails'
 end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem "capybara"
-  gem "selenium-webdriver"
-  gem "webdrivers"
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'webdrivers'
 end

--- a/backend/trip-manager-api/Gemfile
+++ b/backend/trip-manager-api/Gemfile
@@ -34,7 +34,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
@@ -43,6 +43,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem "bootsnap", require: false
 
 gem "graphql"
+gem "jwt"
 
 # Use Sass to process CSS
 # gem "sassc-rails"

--- a/backend/trip-manager-api/Gemfile.lock
+++ b/backend/trip-manager-api/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.1.1)
+    bcrypt (3.1.19)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -113,6 +114,7 @@ GEM
       activesupport (>= 5.0.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    jwt (2.7.1)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -247,6 +249,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   bundler-audit
@@ -256,6 +259,7 @@ DEPENDENCIES
   graphql
   importmap-rails
   jbuilder
+  jwt
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.6)

--- a/backend/trip-manager-api/Gemfile.lock
+++ b/backend/trip-manager-api/Gemfile.lock
@@ -113,8 +113,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
-    language_server-protocol (3.17.0.3)
     jwt (2.7.1)
+    language_server-protocol (3.17.0.3)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -203,6 +203,15 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
+    rubocop-graphql (1.4.0)
+      rubocop (>= 0.90, < 2)
+    rubocop-performance (1.18.0)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.20.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     selenium-webdriver (4.10.0)
@@ -264,6 +273,9 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.6)
   rubocop
+  rubocop-graphql
+  rubocop-performance
+  rubocop-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/backend/trip-manager-api/README.md
+++ b/backend/trip-manager-api/README.md
@@ -10,8 +10,8 @@ Default port has been set to 3005.
 In this project directory, install dependencies and setup the database:
 ```bash
 $ bundle install
-$ rake db:create
-$ rake db:migrate
+$ bundle exec rake db:create
+$ bundle exec rake db:migrate
 ```
 
 Run the development server:
@@ -20,6 +20,14 @@ $ rails s
 ```
 
 
-## Other
+## Common commands
+
+```bash
+# run tests
+$ bundle exec rake test
+```
+
+
+## GraphiQL
 
 You may visit `http://localhost:3005/graphiql` to access GraphiQL, a web interface for testing GraphQL queries and mutations.

--- a/backend/trip-manager-api/Rakefile
+++ b/backend/trip-manager-api/Rakefile
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative "config/application"
+require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/backend/trip-manager-api/app/channels/application_cable/channel.rb
+++ b/backend/trip-manager-api/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/backend/trip-manager-api/app/channels/application_cable/connection.rb
+++ b/backend/trip-manager-api/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/backend/trip-manager-api/app/controllers/application_controller.rb
+++ b/backend/trip-manager-api/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
 end

--- a/backend/trip-manager-api/app/controllers/graphql_controller.rb
+++ b/backend/trip-manager-api/app/controllers/graphql_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GraphqlController < ApplicationController
   # If accessing from outside this domain, nullify the session
   # This allows for outside API access while preventing CSRF attacks,
@@ -12,10 +14,11 @@ class GraphqlController < ApplicationController
       # Query context goes here, for example:
       # current_user: current_user,
     }
-    result = TripManagerApiSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    result = TripManagerApiSchema.execute(query, variables:, context:, operation_name:)
     render json: result
   rescue StandardError => e
     raise e unless Rails.env.development?
+
     handle_error_in_development(e)
   end
 
@@ -45,6 +48,6 @@ class GraphqlController < ApplicationController
     logger.error e.message
     logger.error e.backtrace.join("\n")
 
-    render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
+    render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: :internal_server_error
   end
 end

--- a/backend/trip-manager-api/app/graphql/mutations/base_mutation.rb
+++ b/backend/trip-manager-api/app/graphql/mutations/base_mutation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mutations
   class BaseMutation < GraphQL::Schema::RelayClassicMutation
     argument_class Types::BaseArgument

--- a/backend/trip-manager-api/app/graphql/mutations/create_user.rb
+++ b/backend/trip-manager-api/app/graphql/mutations/create_user.rb
@@ -1,0 +1,26 @@
+module Mutations
+  class CreateUser < BaseMutation
+    # often we will need input types for specific mutation
+    # in those cases we can define those input types in the mutation class itself
+    class AuthProviderSignupData < Types::BaseInputObject
+      argument :credentials, Types::AuthProviderCredentialsInput, required: false
+    end
+
+    argument :auth_provider, AuthProviderSignupData, required: false
+
+    type Types::UserType
+
+    def resolve(name: nil, auth_provider: nil)
+      password = auth_provider&.[](:credentials)&.[](:password)
+      password_confirmation = auth_provider&.[](:credentials)&.[](:password_confirmation)
+
+      return unless password == password_confirmation
+
+      User.create!(
+        email: auth_provider&.[](:credentials)&.[](:email),
+        password: password,
+        password_confirmation: password_confirmation,
+      )
+    end
+  end
+end

--- a/backend/trip-manager-api/app/graphql/mutations/create_user.rb
+++ b/backend/trip-manager-api/app/graphql/mutations/create_user.rb
@@ -1,16 +1,22 @@
+# frozen_string_literal: true
+
 module Mutations
   class CreateUser < BaseMutation
     # often we will need input types for specific mutation
     # in those cases we can define those input types in the mutation class itself
     class AuthProviderSignupData < Types::BaseInputObject
+      description 'Data field for login information'
+
       argument :credentials, Types::AuthProviderCredentialsInput, required: false
     end
+
+    description 'POST request to create user'
 
     argument :auth_provider, AuthProviderSignupData, required: false
 
     type Types::UserType
 
-    def resolve(name: nil, auth_provider: nil)
+    def resolve(auth_provider: nil)
       password = auth_provider&.[](:credentials)&.[](:password)
       password_confirmation = auth_provider&.[](:credentials)&.[](:password_confirmation)
 
@@ -18,8 +24,8 @@ module Mutations
 
       User.create!(
         email: auth_provider&.[](:credentials)&.[](:email),
-        password: password,
-        password_confirmation: password_confirmation,
+        password:,
+        password_confirmation:
       )
     end
   end

--- a/backend/trip-manager-api/app/graphql/mutations/sign_in_user.rb
+++ b/backend/trip-manager-api/app/graphql/mutations/sign_in_user.rb
@@ -1,0 +1,27 @@
+module Mutations
+  class SignInUser < BaseMutation
+    null true
+
+    argument :credentials, Types::AuthProviderCredentialsInput, required: false
+
+    field :token, String, null: true
+    field :user, Types::UserType, null: true
+
+    def resolve(credentials: nil)
+      # TODO: need proper validation
+      return unless credentials
+
+      user = User.find_by(email: credentials[:email].downcase)
+
+      return unless user
+      return unless user.authenticate(credentials[:password])
+
+      crypt = ActiveSupport::MessageEncryptor.new(
+        Rails.application.credentials.secret_key_base.byteslice(0..31)
+      )
+      token = crypt.encrypt_and_sign("user-id:#{ user.id }")
+
+      { user: user , token: token }
+    end
+  end
+end

--- a/backend/trip-manager-api/app/graphql/mutations/sign_in_user.rb
+++ b/backend/trip-manager-api/app/graphql/mutations/sign_in_user.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 module Mutations
   class SignInUser < BaseMutation
     null true
+
+    description 'POST request to login'
 
     argument :credentials, Types::AuthProviderCredentialsInput, required: false
 
@@ -19,9 +23,9 @@ module Mutations
       crypt = ActiveSupport::MessageEncryptor.new(
         Rails.application.credentials.secret_key_base.byteslice(0..31)
       )
-      token = crypt.encrypt_and_sign("user-id:#{ user.id }")
+      token = crypt.encrypt_and_sign("user-id:#{user.id}")
 
-      { user: user , token: token }
+      { user:, token: }
     end
   end
 end

--- a/backend/trip-manager-api/app/graphql/trip_manager_api_schema.rb
+++ b/backend/trip-manager-api/app/graphql/trip_manager_api_schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TripManagerApiSchema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
@@ -6,6 +8,7 @@ class TripManagerApiSchema < GraphQL::Schema
   use GraphQL::Dataloader
 
   # GraphQL-Ruby calls this when something goes wrong while running a query:
+  # rubocop:disable Lint/UselessMethodDefinition
   def self.type_error(err, context)
     # if err.is_a?(GraphQL::InvalidNullError)
     #   # report to your bug tracker here
@@ -13,9 +16,10 @@ class TripManagerApiSchema < GraphQL::Schema
     # end
     super
   end
+  # rubocop:enable Lint/UselessMethodDefinition
 
   # Union and Interface Resolution
-  def self.resolve_type(abstract_type, obj, ctx)
+  def self.resolve_type(_abstract_type, _obj, _ctx)
     # TODO: Implement this method
     # to return the correct GraphQL object type for `obj`
     raise(GraphQL::RequiredImplementationMissingError)
@@ -27,13 +31,13 @@ class TripManagerApiSchema < GraphQL::Schema
   # Relay-style Object Identification:
 
   # Return a string UUID for `object`
-  def self.id_from_object(object, type_definition, query_ctx)
+  def self.id_from_object(object, _type_definition, _query_ctx)
     # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
     object.to_gid_param
   end
 
   # Given a string UUID, find the object
-  def self.object_from_id(global_id, query_ctx)
+  def self.object_from_id(global_id, _query_ctx)
     # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
     GlobalID.find(global_id)
   end

--- a/backend/trip-manager-api/app/graphql/types/auth_provider_credentials_input.rb
+++ b/backend/trip-manager-api/app/graphql/types/auth_provider_credentials_input.rb
@@ -1,0 +1,10 @@
+module Types
+  class AuthProviderCredentialsInput < BaseInputObject
+    # the name is usually inferred by class name but can be overwritten
+    graphql_name 'AUTH_PROVIDER_CREDENTIALS'
+
+    argument :email, String, required: true
+    argument :password, String, required: true
+    argument :password_confirmation, String, required: false
+  end
+end

--- a/backend/trip-manager-api/app/graphql/types/auth_provider_credentials_input.rb
+++ b/backend/trip-manager-api/app/graphql/types/auth_provider_credentials_input.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 module Types
   class AuthProviderCredentialsInput < BaseInputObject
     # the name is usually inferred by class name but can be overwritten
     graphql_name 'AUTH_PROVIDER_CREDENTIALS'
+
+    description 'Data field for login information'
 
     argument :email, String, required: true
     argument :password, String, required: true

--- a/backend/trip-manager-api/app/graphql/types/base_argument.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_argument.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseArgument < GraphQL::Schema::Argument
   end

--- a/backend/trip-manager-api/app/graphql/types/base_connection.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseConnection < Types::BaseObject
     # add `nodes` and `pageInfo` fields, as well as `edge_type(...)` and `node_nullable(...)` overrides

--- a/backend/trip-manager-api/app/graphql/types/base_edge.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_edge.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseEdge < Types::BaseObject
     # add `node` and `cursor` fields, as well as `node_type(...)` override

--- a/backend/trip-manager-api/app/graphql/types/base_enum.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_enum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseEnum < GraphQL::Schema::Enum
   end

--- a/backend/trip-manager-api/app/graphql/types/base_field.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument

--- a/backend/trip-manager-api/app/graphql/types/base_input_object.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_input_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseInputObject < GraphQL::Schema::InputObject
     argument_class Types::BaseArgument

--- a/backend/trip-manager-api/app/graphql/types/base_interface.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_interface.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   module BaseInterface
     include GraphQL::Schema::Interface

--- a/backend/trip-manager-api/app/graphql/types/base_object.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseObject < GraphQL::Schema::Object
     edge_type_class(Types::BaseEdge)

--- a/backend/trip-manager-api/app/graphql/types/base_scalar.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_scalar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseScalar < GraphQL::Schema::Scalar
   end

--- a/backend/trip-manager-api/app/graphql/types/base_union.rb
+++ b/backend/trip-manager-api/app/graphql/types/base_union.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseUnion < GraphQL::Schema::Union
     edge_type_class(Types::BaseEdge)

--- a/backend/trip-manager-api/app/graphql/types/mutation_type.rb
+++ b/backend/trip-manager-api/app/graphql/types/mutation_type.rb
@@ -1,10 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
+    field :create_user, mutation: Mutations::CreateUser
+    field :sign_in_user, mutation: Mutations::SignInUser
   end
 end

--- a/backend/trip-manager-api/app/graphql/types/mutation_type.rb
+++ b/backend/trip-manager-api/app/graphql/types/mutation_type.rb
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
 module Types
   class MutationType < Types::BaseObject
+    description 'All mutations'
+
     field :create_user, mutation: Mutations::CreateUser
     field :sign_in_user, mutation: Mutations::SignInUser
   end

--- a/backend/trip-manager-api/app/graphql/types/node_type.rb
+++ b/backend/trip-manager-api/app/graphql/types/node_type.rb
@@ -2,10 +2,10 @@
 
 module Types
   module NodeType
-    description 'Base Node Type'
-
     include Types::BaseInterface
     # Add the `id` field
     include GraphQL::Types::Relay::NodeBehaviors
+
+    description 'Base Node Type'
   end
 end

--- a/backend/trip-manager-api/app/graphql/types/node_type.rb
+++ b/backend/trip-manager-api/app/graphql/types/node_type.rb
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
 module Types
   module NodeType
+    description 'Base Node Type'
+
     include Types::BaseInterface
     # Add the `id` field
     include GraphQL::Types::Relay::NodeBehaviors

--- a/backend/trip-manager-api/app/graphql/types/query_type.rb
+++ b/backend/trip-manager-api/app/graphql/types/query_type.rb
@@ -4,14 +4,9 @@ module Types
     include GraphQL::Types::Relay::HasNodeField
     include GraphQL::Types::Relay::HasNodesField
 
-    # Add root-level fields here.
-    # They will be entry points for queries on your schema.
-
-    # TODO: remove me
-    # field :test_field, String, null: false,
-    #   description: "An example field added by the generator"
-    # def test_field
-    #   "Hello World!"
-    # end
+    field :users, [UserType], null: false, description: "Get all Users"
+    def users
+      User.all
+    end
   end
 end

--- a/backend/trip-manager-api/app/graphql/types/query_type.rb
+++ b/backend/trip-manager-api/app/graphql/types/query_type.rb
@@ -1,10 +1,14 @@
+# frozen_string_literal: true
+
 module Types
   class QueryType < Types::BaseObject
+    description 'Base Query Type'
+
     # Add `node(id: ID!) and `nodes(ids: [ID!]!)`
     include GraphQL::Types::Relay::HasNodeField
     include GraphQL::Types::Relay::HasNodesField
 
-    field :users, [UserType], null: false, description: "Get all Users"
+    field :users, [UserType], null: false, description: 'Get all Users'
     def users
       User.all
     end

--- a/backend/trip-manager-api/app/graphql/types/user_type.rb
+++ b/backend/trip-manager-api/app/graphql/types/user_type.rb
@@ -2,10 +2,10 @@
 
 module Types
   class UserType < Types::BaseObject
-    graphql_name "User"
+    description 'Base User Type'
 
-    field :id, ID, null: false
-    field :email, String, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :email, String, null: false
+    field :id, ID, null: false
   end
 end

--- a/backend/trip-manager-api/app/graphql/types/user_type.rb
+++ b/backend/trip-manager-api/app/graphql/types/user_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class UserType < Types::BaseObject
+    graphql_name "User"
+
+    field :id, ID, null: false
+    field :email, String, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/backend/trip-manager-api/app/helpers/application_helper.rb
+++ b/backend/trip-manager-api/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/backend/trip-manager-api/app/jobs/application_job.rb
+++ b/backend/trip-manager-api/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/backend/trip-manager-api/app/mailers/application_mailer.rb
+++ b/backend/trip-manager-api/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
-  layout "mailer"
+  default from: 'from@example.com'
+  layout 'mailer'
 end

--- a/backend/trip-manager-api/app/models/application_record.rb
+++ b/backend/trip-manager-api/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 end

--- a/backend/trip-manager-api/app/models/user.rb
+++ b/backend/trip-manager-api/app/models/user.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   before_save { self.email = email.downcase }
 
   has_secure_password
 
   validates :email,
-    presence: true,
-    uniqueness: { case_sensitive: false },
-    length: { maximum: 255 },
-    format: { with: URI::MailTo::EMAIL_REGEXP }
+            presence: true,
+            uniqueness: { case_sensitive: false },
+            length: { maximum: 255 },
+            format: { with: URI::MailTo::EMAIL_REGEXP }
 
   validates :password,
-    length: { minimum: 6 }
+            length: { minimum: 6 }
 end

--- a/backend/trip-manager-api/app/models/user.rb
+++ b/backend/trip-manager-api/app/models/user.rb
@@ -1,0 +1,14 @@
+class User < ApplicationRecord
+  before_save { self.email = email.downcase }
+
+  has_secure_password
+
+  validates :email,
+    presence: true,
+    uniqueness: { case_sensitive: false },
+    length: { maximum: 255 },
+    format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  validates :password,
+    length: { minimum: 6 }
+end

--- a/backend/trip-manager-api/bin/bundle
+++ b/backend/trip-manager-api/bin/bundle
@@ -8,46 +8,46 @@
 # this file is here to facilitate running it.
 #
 
-require "rubygems"
+require 'rubygems'
 
 m = Module.new do
   module_function
 
   def invoked_as_script?
-    File.expand_path($0) == File.expand_path(__FILE__)
+    File.expand_path($PROGRAM_NAME) == File.expand_path(__FILE__)
   end
 
   def env_var_version
-    ENV["BUNDLER_VERSION"]
+    ENV['BUNDLER_VERSION']
   end
 
   def cli_arg_version
     return unless invoked_as_script? # don't want to hijack other binstubs
-    return unless "update".start_with?(ARGV.first || " ") # must be running `bundle update`
+    return unless 'update'.start_with?(ARGV.first || ' ') # must be running `bundle update`
+
     bundler_version = nil
     update_index = nil
     ARGV.each_with_index do |a, i|
-      if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
-        bundler_version = a
-      end
+      bundler_version = a if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
       next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
-      bundler_version = $1
+
+      bundler_version = Regexp.last_match(1)
       update_index = i
     end
     bundler_version
   end
 
   def gemfile
-    gemfile = ENV["BUNDLE_GEMFILE"]
+    gemfile = ENV['BUNDLE_GEMFILE']
     return gemfile if gemfile && !gemfile.empty?
 
-    File.expand_path("../Gemfile", __dir__)
+    File.expand_path('../Gemfile', __dir__)
   end
 
   def lockfile
     lockfile =
       case File.basename(gemfile)
-      when "gems.rb" then gemfile.sub(/\.rb$/, ".locked")
+      when 'gems.rb' then gemfile.sub(/\.rb$/, '.locked')
       else "#{gemfile}.lock"
       end
     File.expand_path(lockfile)
@@ -55,8 +55,10 @@ m = Module.new do
 
   def lockfile_version
     return unless File.file?(lockfile)
+
     lockfile_contents = File.read(lockfile)
     return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+
     Regexp.last_match(1)
   end
 
@@ -76,20 +78,24 @@ m = Module.new do
   end
 
   def load_bundler!
-    ENV["BUNDLE_GEMFILE"] ||= gemfile
+    ENV['BUNDLE_GEMFILE'] ||= gemfile
 
     activate_bundler
   end
 
   def activate_bundler
     gem_error = activation_error_handling do
-      gem "bundler", bundler_requirement
+      gem 'bundler', bundler_requirement
     end
     return if gem_error.nil?
+
     require_error = activation_error_handling do
-      require "bundler/version"
+      require 'bundler/version'
     end
-    return if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
+    if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
+      return
+    end
+
     warn "Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`"
     exit 42
   end
@@ -104,6 +110,4 @@ end
 
 m.load_bundler!
 
-if m.invoked_as_script?
-  load Gem.bin_path("bundler", "bundle")
-end
+load Gem.bin_path('bundler', 'bundle') if m.invoked_as_script?

--- a/backend/trip-manager-api/bin/importmap
+++ b/backend/trip-manager-api/bin/importmap
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require_relative "../config/application"
-require "importmap/commands"
+require_relative '../config/application'
+require 'importmap/commands'

--- a/backend/trip-manager-api/bin/rails
+++ b/backend/trip-manager-api/bin/rails
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path("../config/application", __dir__)
-require_relative "../config/boot"
-require "rails/commands"
+# frozen_string_literal: true
+
+APP_PATH = File.expand_path('../config/application', __dir__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/backend/trip-manager-api/bin/rake
+++ b/backend/trip-manager-api/bin/rake
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-require_relative "../config/boot"
-require "rake"
+# frozen_string_literal: true
+
+require_relative '../config/boot'
+require 'rake'
 Rake.application.run

--- a/backend/trip-manager-api/bin/setup
+++ b/backend/trip-manager-api/bin/setup
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
-require "fileutils"
+# frozen_string_literal: true
+
+require 'fileutils'
 
 # path to your application root.
-APP_ROOT = File.expand_path("..", __dir__)
+APP_ROOT = File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,9 +15,9 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts "== Installing dependencies =="
-  system! "gem install bundler --conservative"
-  system("bundle check") || system!("bundle install")
+  puts '== Installing dependencies =='
+  system! 'gem install bundler --conservative'
+  system('bundle check') || system!('bundle install')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
@@ -23,11 +25,11 @@ FileUtils.chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! "bin/rails db:prepare"
+  system! 'bin/rails db:prepare'
 
   puts "\n== Removing old logs and tempfiles =="
-  system! "bin/rails log:clear tmp:clear"
+  system! 'bin/rails log:clear tmp:clear'
 
   puts "\n== Restarting application server =="
-  system! "bin/rails restart"
+  system! 'bin/rails restart'
 end

--- a/backend/trip-manager-api/config.ru
+++ b/backend/trip-manager-api/config.ru
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/backend/trip-manager-api/config/application.rb
+++ b/backend/trip-manager-api/config/application.rb
@@ -1,6 +1,8 @@
-require_relative "boot"
+# frozen_string_literal: true
 
-require "rails/all"
+require_relative 'boot'
+
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/backend/trip-manager-api/config/boot.rb
+++ b/backend/trip-manager-api/config/boot.rb
@@ -1,4 +1,6 @@
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+# frozen_string_literal: true
 
-require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+
+require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/backend/trip-manager-api/config/environment.rb
+++ b/backend/trip-manager-api/config/environment.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
-require_relative "application"
+require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/backend/trip-manager-api/config/environments/development.rb
+++ b/backend/trip-manager-api/config/environments/development.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -19,13 +21,13 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist?
+  if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
+      'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/backend/trip-manager-api/config/environments/production.rb
+++ b/backend/trip-manager-api/config/environments/production.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -22,7 +24,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
@@ -53,7 +55,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -82,8 +84,10 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    # rubocop:disable Style/GlobalStdStream
     logger           = ActiveSupport::Logger.new(STDOUT)
+    # rubocop:enable Style/GlobalStdStream
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/backend/trip-manager-api/config/environments/test.rb
+++ b/backend/trip-manager-api/config/environments/test.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -14,12 +16,12 @@ Rails.application.configure do
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/backend/trip-manager-api/config/importmap.rb
+++ b/backend/trip-manager-api/config/importmap.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 # Pin npm packages by running ./bin/importmap
 
-pin "application", preload: true
-pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
-pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
-pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
-pin_all_from "app/javascript/controllers", under: "controllers"
+pin 'application', preload: true
+pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
+pin '@hotwired/stimulus', to: 'stimulus.min.js', preload: true
+pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
+pin_all_from 'app/javascript/controllers', under: 'controllers'

--- a/backend/trip-manager-api/config/initializers/assets.rb
+++ b/backend/trip-manager-api/config/initializers/assets.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = "1.0"
+Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/backend/trip-manager-api/config/initializers/content_security_policy.rb
+++ b/backend/trip-manager-api/config/initializers/content_security_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy.

--- a/backend/trip-manager-api/config/initializers/filter_parameter_logging.rb
+++ b/backend/trip-manager-api/config/initializers/filter_parameter_logging.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be filtered from the log file. Use this to limit dissemination of
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
-Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+Rails.application.config.filter_parameters += %i[
+  passw secret token _key crypt salt certificate otp ssn
 ]

--- a/backend/trip-manager-api/config/initializers/inflections.rb
+++ b/backend/trip-manager-api/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/backend/trip-manager-api/config/initializers/permissions_policy.rb
+++ b/backend/trip-manager-api/config/initializers/permissions_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Define an application-wide HTTP permissions policy. For further
 # information see https://developers.google.com/web/updates/2018/06/feature-policy
 #

--- a/backend/trip-manager-api/config/puma.rb
+++ b/backend/trip-manager-api/config/puma.rb
@@ -1,28 +1,30 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS', max_threads_count)
 threads min_threads_count, max_threads_count
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3005 }
+port ENV.fetch('PORT', 3005)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV', 'development')
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/backend/trip-manager-api/config/routes.rb
+++ b/backend/trip-manager-api/config/routes.rb
@@ -1,8 +1,8 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
-  if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
-  end
-  post "/graphql", to: "graphql#execute"
+  mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql' if Rails.env.development?
+  post '/graphql', to: 'graphql#execute'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/backend/trip-manager-api/db/migrate/20230725000556_create_users.rb
+++ b/backend/trip-manager-api/db/migrate/20230725000556_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/trip-manager-api/db/migrate/20230725000556_create_users.rb
+++ b/backend/trip-manager-api/db/migrate/20230725000556_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUsers < ActiveRecord::Migration[7.0]
   def change
     create_table :users do |t|

--- a/backend/trip-manager-api/db/migrate/20230808210850_add_index_to_users_email.rb
+++ b/backend/trip-manager-api/db/migrate/20230808210850_add_index_to_users_email.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIndexToUsersEmail < ActiveRecord::Migration[7.0]
   def change
     add_index :users, :email, unique: true

--- a/backend/trip-manager-api/db/migrate/20230808210850_add_index_to_users_email.rb
+++ b/backend/trip-manager-api/db/migrate/20230808210850_add_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsersEmail < ActiveRecord::Migration[7.0]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/backend/trip-manager-api/db/schema.rb
+++ b/backend/trip-manager-api/db/schema.rb
@@ -10,8 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_08_210850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
 
 end

--- a/backend/trip-manager-api/db/schema.rb
+++ b/backend/trip-manager-api/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,16 +12,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_08_210850) do
+ActiveRecord::Schema[7.0].define(version: 20_230_808_210_850) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "users", force: :cascade do |t|
-    t.string "email"
-    t.string "password_digest"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'email'
+    t.string 'password_digest'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
-
 end

--- a/backend/trip-manager-api/db/seeds.rb
+++ b/backend/trip-manager-api/db/seeds.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #

--- a/backend/trip-manager-api/test/application_system_test_case.rb
+++ b/backend/trip-manager-api/test/application_system_test_case.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/backend/trip-manager-api/test/channels/application_cable/connection_test.rb
+++ b/backend/trip-manager-api/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do

--- a/backend/trip-manager-api/test/fixtures/users.yml
+++ b/backend/trip-manager-api/test/fixtures/users.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+anne:
+  email: anne@example.com
+  password_digest: MyString
+
+bob:
+  email: bob@example.com
+  password_digest: MyString

--- a/backend/trip-manager-api/test/models/user_test.rb
+++ b/backend/trip-manager-api/test/models/user_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+TEST_EMAIL = 'TestUser@Example.com'
+
+class UserTest < ActiveSupport::TestCase
+
+  def setup
+    @user = perform(
+      auth_provider: {
+        credentials: {
+          email: TEST_EMAIL,
+          password: '[omitted]',
+          password_confirmation: '[omitted]'
+        }
+      }
+    )
+  end
+
+  def perform(args = {})
+    Mutations::CreateUser.new(object: nil, field: nil, context: {}).resolve(**args)
+  end
+
+  def sign_in_user(args = {})
+    Mutations::SignInUser.new(object: nil, field: nil, context: {}).resolve(**args)
+  end
+
+  test 'create new user' do
+    assert @user.valid?
+    assert @user.persisted?
+  end
+
+  test "email should be saved lowercase" do
+    assert_equal @user.email, TEST_EMAIL.downcase
+  end
+
+  test "email should be present" do
+    @user.email = "   "
+    assert_not @user.valid?
+  end
+
+  test "email should be unique, case insensitive" do
+    user2 = @user.dup
+    # uniqueness should be case insensitive
+    user2.email = @user.email.upcase
+    # save to generate errors
+    @user.save
+
+    assert_not user2.valid?
+    assert user2.errors
+    assert user2.errors[:email]
+  end
+
+  test "email should not be too long" do
+    @user.email = "a" * 244 + "@example.com"
+    assert_not @user.valid?
+  end
+
+  test "email validation should accept valid addresses" do
+    valid_addresses = %w[user@example.com USER@google.COM A_U-s+er@foo.bar.org first.last@foo.jp a+b@baz.cn]
+
+    valid_addresses.each do |valid_address|
+      @user.email = valid_address
+      assert @user.valid?, "#{valid_address.inspect} should be valid"
+    end
+  end
+
+  test "email validation should reject invalid addresses" do
+    invalid_addresses = %w[user@example,com user_at_example.org user.name@example.foo@baz.com foo@bar+baz.cn]
+
+    invalid_addresses.each do |invalid_address|
+      @user.email = invalid_address
+      assert_not @user.valid?, "#{invalid_address.inspect} should be invalid"
+    end
+  end
+
+  test "password should have a minimum length" do
+    @user.password = @user.password_confirmation = "a" * 5
+
+    assert_not @user.valid?
+  end
+
+  test "user can login with correct password" do
+    login_response = sign_in_user(
+      credentials: {
+        email: TEST_EMAIL,
+        password: "[omitted]"
+      }
+    )
+
+    assert_equal login_response[:user].email, @user.email
+    assert login_response[:token]
+  end
+
+  test "user cannot login with incorrect password" do
+    # TODO: need better response
+    login_response = sign_in_user(
+      credentials: {
+        email: TEST_EMAIL,
+        password: "INCORRECT_PASSWORD"
+      }
+    )
+
+    assert_not login_response
+  end
+
+end

--- a/backend/trip-manager-api/test/models/user_test.rb
+++ b/backend/trip-manager-api/test/models/user_test.rb
@@ -1,9 +1,10 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 TEST_EMAIL = 'TestUser@Example.com'
 
 class UserTest < ActiveSupport::TestCase
-
   def setup
     @user = perform(
       auth_provider: {
@@ -29,16 +30,16 @@ class UserTest < ActiveSupport::TestCase
     assert @user.persisted?
   end
 
-  test "email should be saved lowercase" do
+  test 'email should be saved lowercase' do
     assert_equal @user.email, TEST_EMAIL.downcase
   end
 
-  test "email should be present" do
-    @user.email = "   "
+  test 'email should be present' do
+    @user.email = '   '
     assert_not @user.valid?
   end
 
-  test "email should be unique, case insensitive" do
+  test 'email should be unique, case insensitive' do
     user2 = @user.dup
     # uniqueness should be case insensitive
     user2.email = @user.email.upcase
@@ -50,12 +51,12 @@ class UserTest < ActiveSupport::TestCase
     assert user2.errors[:email]
   end
 
-  test "email should not be too long" do
-    @user.email = "a" * 244 + "@example.com"
+  test 'email should not be too long' do
+    @user.email = "#{'a' * 244}@example.com"
     assert_not @user.valid?
   end
 
-  test "email validation should accept valid addresses" do
+  test 'email validation should accept valid addresses' do
     valid_addresses = %w[user@example.com USER@google.COM A_U-s+er@foo.bar.org first.last@foo.jp a+b@baz.cn]
 
     valid_addresses.each do |valid_address|
@@ -64,7 +65,7 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test "email validation should reject invalid addresses" do
+  test 'email validation should reject invalid addresses' do
     invalid_addresses = %w[user@example,com user_at_example.org user.name@example.foo@baz.com foo@bar+baz.cn]
 
     invalid_addresses.each do |invalid_address|
@@ -73,17 +74,17 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test "password should have a minimum length" do
-    @user.password = @user.password_confirmation = "a" * 5
+  test 'password should have a minimum length' do
+    @user.password = @user.password_confirmation = 'a' * 5
 
     assert_not @user.valid?
   end
 
-  test "user can login with correct password" do
+  test 'user can login with correct password' do
     login_response = sign_in_user(
       credentials: {
         email: TEST_EMAIL,
-        password: "[omitted]"
+        password: '[omitted]'
       }
     )
 
@@ -91,16 +92,15 @@ class UserTest < ActiveSupport::TestCase
     assert login_response[:token]
   end
 
-  test "user cannot login with incorrect password" do
+  test 'user cannot login with incorrect password' do
     # TODO: need better response
     login_response = sign_in_user(
       credentials: {
         email: TEST_EMAIL,
-        password: "INCORRECT_PASSWORD"
+        password: 'INCORRECT_PASSWORD'
       }
     )
 
     assert_not login_response
   end
-
 end

--- a/backend/trip-manager-api/test/test_helper.rb
+++ b/backend/trip-manager-api/test/test_helper.rb
@@ -1,6 +1,8 @@
-ENV["RAILS_ENV"] ||= "test"
-require_relative "../config/environment"
-require "rails/test_help"
+# frozen_string_literal: true
+
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+require 'rails/test_help'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
In this PR, we add:
- User model
- Create user mutation
- Sign-in user mutation
- basic auth

There are still many things to work on here including:
- Better validation on sign-in
- Better password strength requirement
- Looking into adding devise and jwt
- Authentication middleware
- Figuring out how apollo server works in the grand scheme of things
- Email confirmation
- Google OAuth


Please note that this is going beyond what is necessary for a simple app like this, but the main goal of this application is to learn these technologies and use-cases through building them